### PR TITLE
Fix emscripten build with tail-call flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -407,6 +407,7 @@ else ifneq (,$(findstring armv,$(platform)))
 else ifeq ($(platform), emscripten)
 	TARGET := $(TARGET_NAME)_libretro_$(platform).bc
 	STATIC_LINKING=1
+	CFLAGS += -mtail-call
 
 # GCW0
 else ifeq ($(platform), gcw0)


### PR DESCRIPTION
This fixes the emscripten build under EMSDK 3.1.46.  It's kind of funny to have emscripten compile C code implementing a wasm interpreter.