### PR TITLE
Dummy out musttail attributes under emscripten builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -407,7 +407,7 @@ else ifneq (,$(findstring armv,$(platform)))
 else ifeq ($(platform), emscripten)
 	TARGET := $(TARGET_NAME)_libretro_$(platform).bc
 	STATIC_LINKING=1
-	CFLAGS += -mtail-call
+	CFLAGS += -Dmusttail='emscripten_asyncify_does_not_support_musttail'
 
 # GCW0
 else ifeq ($(platform), gcw0)


### PR DESCRIPTION
Even though the core could compile with `-mtail-call`, we compile retroarch using asyncify which does not support them.  So this patch instead causes the "musttail" feature detection of wasm3 to decide that musttail doesn't exist.  musttail only appears in two places in the uw8/wasm3 source trees, so this seems safe.